### PR TITLE
Inspect AWS caller identity

### DIFF
--- a/packermate/config.py
+++ b/packermate/config.py
@@ -17,10 +17,10 @@ import logging
 try:
     import boto3
     from botocore.exceptions import BotoCoreError
-    BOTO3_AVAIABLE = True
+    BOTO3_AVAILABLE = True
 
 except ImportError:
-    BOTO3_AVAIABLE = False
+    BOTO3_AVAILABLE = False
 
 
 CONFIG_DEFAULTS = {
@@ -145,7 +145,7 @@ class ConfigValue(object):
 
         process_func_list = []
 
-        if BOTO3_AVAIABLE:
+        if BOTO3_AVAILABLE:
             process_func_list += [
                 self.ProcessFuncInfo(('aws_account',), 1, self._get_aws_account),
                 self.ProcessFuncInfo(('aws_account',), 2, self._get_aws_account),

--- a/packermate/config.py
+++ b/packermate/config.py
@@ -51,12 +51,15 @@ class ConfigLoadFormatException(ConfigLoadException):
     pass
 
 
-def get_aws_caller_identity():
+def get_aws_caller_identity(key, default = None):
     try:
         sts_client = boto3.client('sts')
-        return sts_client.get_caller_identity()
+        return sts_client.get_caller_identity()[key]
 
     except BotoCoreError as e:
+        if default is not None:
+            return default
+
         raise ConfigException('AWS error ({}) {}'.format(e.__class__.__name__, e))
 
 
@@ -145,8 +148,11 @@ class ConfigValue(object):
         if BOTO3_AVAIABLE:
             process_func_list += [
                 self.ProcessFuncInfo(('aws_account',), 1, self._get_aws_account),
+                self.ProcessFuncInfo(('aws_account',), 2, self._get_aws_account),
                 self.ProcessFuncInfo(('aws_user',), 1, self._get_aws_user),
-                self.ProcessFuncInfo(('aws_arn',), 1, self._get_aws_arn)
+                self.ProcessFuncInfo(('aws_user',), 2, self._get_aws_user),
+                self.ProcessFuncInfo(('aws_arn',), 1, self._get_aws_arn),
+                self.ProcessFuncInfo(('aws_arn',), 2, self._get_aws_arn),
             ]
 
         process_func_list += [
@@ -277,16 +283,16 @@ class ConfigValue(object):
         return self._get_tar_file_data('tgz', tar_name, file_name)
 
     @staticmethod
-    def _get_aws_account():
-        return get_aws_caller_identity()['Account']
+    def _get_aws_account(default = None):
+        return get_aws_caller_identity('Account', default)
 
     @staticmethod
-    def _get_aws_user():
-        return get_aws_caller_identity()['UserId']
+    def _get_aws_user(default = None):
+        return get_aws_caller_identity('UserId', default)
 
     @staticmethod
-    def _get_aws_arn():
-        return get_aws_caller_identity()['Arn']
+    def _get_aws_arn(default = None):
+        return get_aws_caller_identity('Arn', default)
 
 
 def get_env_var(name, default = None):

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,10 @@ setup(
         'semantic_version==2.6.0',
         'requests==2.18.1',
     ],
+    extras_require = {
+        'AWS':  [
+            "boto3==1.4.4"
+        ]
+    },
     zip_safe = False
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,6 +146,7 @@ empty: ''
         ('(( lookup_optional | {} | (( foo )) ))'.format(MISSING_FILE_NAME), '123'),
         ('(( base64_encode | 123 ))', 'MTIz'),
         ('(( base64_decode | (( base64_encode | 123 )) ))', '123'),
+        ('(( aws_account ))', 'aws'),
     ),
 )
 def test_config_value(config_value_config, config_val_str, expected):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,7 +146,6 @@ empty: ''
         ('(( lookup_optional | {} | (( foo )) ))'.format(MISSING_FILE_NAME), '123'),
         ('(( base64_encode | 123 ))', 'MTIz'),
         ('(( base64_decode | (( base64_encode | 123 )) ))', '123'),
-        ('(( aws_account ))', 'aws'),
     ),
 )
 def test_config_value(config_value_config, config_val_str, expected):
@@ -185,6 +184,9 @@ def test_config_value(config_value_config, config_val_str, expected):
         '(( lookup ))',
         '(( lookup | {} ))'.format(MISSING_FILE_NAME),
         '(( lookup | {} | test ))'.format(MISSING_FILE_NAME),
+        '(( aws_account ))',
+        '(( aws_user ))',
+        '(( aws_arn ))',
     )
 )
 def test_config_value_error(config_value_config, config_val_str):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,6 +146,9 @@ empty: ''
         ('(( lookup_optional | {} | (( foo )) ))'.format(MISSING_FILE_NAME), '123'),
         ('(( base64_encode | 123 ))', 'MTIz'),
         ('(( base64_decode | (( base64_encode | 123 )) ))', '123'),
+        ('(( aws_account | meh ))', 'meh'),
+        ('(( aws_user | meh  ))', 'meh'),
+        ('(( aws_arn | meh  ))', 'meh'),
     ),
 )
 def test_config_value(config_value_config, config_val_str, expected):

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = prep, py27, stats
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
-usedevelop=True
-deps=
+usedevelop = True
+deps =
     pyaml==16.12.2
     semantic_version==2.6.0
     requests[security]==2.18.1
@@ -13,17 +13,18 @@ deps=
     flake8==3.3.0
     coverage==4.4.1
     codecov==2.0.9
-commands=
+extras = AWS
+commands =
     coverage run {envbindir}/py.test --basetemp={envtmpdir} {posargs}
 
 [testenv:prep]
-commands=
+commands =
     coverage erase
 ; TODO fix flake8 issues!
 ;    flake8
 
 [testenv:stats]
-commands=
+commands =
     coverage report
     - codecov
 


### PR DESCRIPTION
* Use boto3 STS client to inspect AWS caller identity info.
* Adds pip extra 'AWS'
* Adds config commands: aws_account, aws_user, aws_arn